### PR TITLE
Ticks' max attribute

### DIFF
--- a/src/Options/Scales/Ticks.php
+++ b/src/Options/Scales/Ticks.php
@@ -454,11 +454,15 @@ class Ticks implements ArraySerializableInterface, \JsonSerializable
 	}
 
 	/**
-	 * @param int $max
+	 * @param $max
+	 *
+	 * @return $this
 	 */
 	public function setMax($max)
 	{
 		$this->max = $max;
+
+		return $this;
 	}
 
 	/**

--- a/src/Options/Scales/Ticks.php
+++ b/src/Options/Scales/Ticks.php
@@ -454,7 +454,7 @@ class Ticks implements ArraySerializableInterface, \JsonSerializable
 	}
 
 	/**
-	 * @param $max
+	 * @param int $max
 	 *
 	 * @return $this
 	 */

--- a/src/Options/Scales/Ticks.php
+++ b/src/Options/Scales/Ticks.php
@@ -458,9 +458,9 @@ class Ticks implements ArraySerializableInterface, \JsonSerializable
 	 *
 	 * @return $this
 	 */
-	public function setMax($max)
+	public function setMax( $max )
 	{
-		$this->max = $max;
+		$this->max = intval( $max );
 
 		return $this;
 	}

--- a/src/Options/Scales/Ticks.php
+++ b/src/Options/Scales/Ticks.php
@@ -101,6 +101,11 @@ class Ticks implements ArraySerializableInterface, \JsonSerializable
 	private $reverse;
 
 	/**
+	 * @var int
+	 */
+	private $max;
+
+	/**
 	 * @return float
 	 */
 	public function getSuggestedMin()
@@ -438,6 +443,22 @@ class Ticks implements ArraySerializableInterface, \JsonSerializable
 		$this->reverse = !!$reverse;
 
 		return $this;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getMax()
+	{
+		return $this->max;
+	}
+
+	/**
+	 * @param int $max
+	 */
+	public function setMax($max)
+	{
+		$this->max = $max;
 	}
 
 	/**


### PR DESCRIPTION
This PR adds the `max` attribute on Ticks. It makes possible to set a max value on an axis.
